### PR TITLE
Ccs 32 testing pipeline

### DIFF
--- a/.github/workflows/setting_up.yml
+++ b/.github/workflows/setting_up.yml
@@ -1,9 +1,8 @@
 name: setting_up
 
 on:
-  push:
-    branches:
-      - "CCS-32 Testing-Pipeline"
+  workflow_dispatch:
+
 
 jobs:
   print:


### PR DESCRIPTION
Actions can sadly only be run if the YAML file is in the main branch. This is a GitHub limitation. Thankfully, you can still pick which branch the action should actually run on.
This adds a rudimentary action that prints to console to check if actions work.
Further work will be done in a seperate branch, which should be triggerable as long as the .yml file also exists in main.