### PR TITLE
test/exam-teacher-views

### DIFF
--- a/elearning/final_exam/views/teacher_views.py
+++ b/elearning/final_exam/views/teacher_views.py
@@ -5,7 +5,7 @@ from django.shortcuts import get_object_or_404
 
 # Angepasste Importe
 from ..models import ExamAttempt, ExamCriterion, CriterionScore
-from ..serializers import TeacherSubmissionSerializer, GradeSubmissionSerializer, TeacherGradingSerializer
+from ..serializers import TeacherSubmissionSerializer, TeacherGradingSerializer
 
 
 class TeacherSubmissionsListView(generics.ListAPIView):
@@ -21,18 +21,15 @@ class TeacherSubmissionsListView(generics.ListAPIView):
 
 
 # elearning/final_exam/views/teacher_views.py
-from rest_framework import generics, permissions, status
-from rest_framework.views import APIView
-from rest_framework.response import Response
-from django.shortcuts import get_object_or_404
+from rest_framework import generics, permissions
 from django.utils import timezone
 
-from ..models import ExamAttempt, ExamCriterion, CriterionScore, Exam
+from ..models import Exam
 from ..serializers import (
     TeacherSubmissionSerializer,
-    TeacherGradingSerializer,   # <- this is your GradeSubmissionSerializer alias
     ExamListSerializer,
 )
+
 
 class TeacherSubmissionsListView(generics.ListAPIView):
     serializer_class = TeacherSubmissionSerializer
@@ -40,11 +37,11 @@ class TeacherSubmissionsListView(generics.ListAPIView):
 
     def get_queryset(self):
         return (
-            ExamAttempt.objects
-            .filter(status=ExamAttempt.Status.SUBMITTED)
+            ExamAttempt.objects.filter(status=ExamAttempt.Status.SUBMITTED)
             .select_related("user", "exam")
             .order_by("submitted_at")
         )
+
 
 class TeacherGradeAttemptView(APIView):
     permission_classes = [permissions.IsAdminUser]
@@ -58,7 +55,8 @@ class TeacherGradeAttemptView(APIView):
         if isinstance(scores, dict):
             # convert {"12": 9, "13": 4} -> [{"criterion_id": 12, "achieved_points": 9}, ...]
             data["scores"] = [
-                {"criterion_id": int(k), "achieved_points": v} for k, v in scores.items()
+                {"criterion_id": int(k), "achieved_points": v}
+                for k, v in scores.items()
             ]
 
         serializer = TeacherGradingSerializer(
@@ -74,7 +72,9 @@ class TeacherGradeAttemptView(APIView):
         for item in scores_data:
             criterion_id = item["criterion_id"]
             points = item["achieved_points"]
-            criterion = get_object_or_404(ExamCriterion, pk=criterion_id, exam=attempt.exam)
+            criterion = get_object_or_404(
+                ExamCriterion, pk=criterion_id, exam=attempt.exam
+            )
             CriterionScore.objects.update_or_create(
                 attempt=attempt,
                 criterion=criterion,
@@ -87,7 +87,10 @@ class TeacherGradeAttemptView(APIView):
         attempt.graded_at = timezone.now()
         attempt.save(update_fields=["feedback", "graded_by", "status", "graded_at"])
 
-        return Response({"message": "Bewertung erfolgreich gespeichert."}, status=status.HTTP_200_OK)
+        return Response(
+            {"message": "Bewertung erfolgreich gespeichert."}, status=status.HTTP_200_OK
+        )
+
 
 class AllExamsListView(generics.ListAPIView):
     queryset = Exam.objects.all()

--- a/elearning/final_exam/views/teacher_views.py
+++ b/elearning/final_exam/views/teacher_views.py
@@ -5,7 +5,7 @@ from django.shortcuts import get_object_or_404
 
 # Angepasste Importe
 from ..models import ExamAttempt, ExamCriterion, CriterionScore
-from ..serializers import TeacherSubmissionSerializer, GradeSubmissionSerializer
+from ..serializers import TeacherSubmissionSerializer, GradeSubmissionSerializer, TeacherGradingSerializer
 
 
 class TeacherSubmissionsListView(generics.ListAPIView):
@@ -20,23 +20,61 @@ class TeacherSubmissionsListView(generics.ListAPIView):
         )
 
 
+# elearning/final_exam/views/teacher_views.py
+from rest_framework import generics, permissions, status
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from django.shortcuts import get_object_or_404
+from django.utils import timezone
+
+from ..models import ExamAttempt, ExamCriterion, CriterionScore, Exam
+from ..serializers import (
+    TeacherSubmissionSerializer,
+    TeacherGradingSerializer,   # <- this is your GradeSubmissionSerializer alias
+    ExamListSerializer,
+)
+
+class TeacherSubmissionsListView(generics.ListAPIView):
+    serializer_class = TeacherSubmissionSerializer
+    permission_classes = [permissions.IsAdminUser]
+
+    def get_queryset(self):
+        return (
+            ExamAttempt.objects
+            .filter(status=ExamAttempt.Status.SUBMITTED)
+            .select_related("user", "exam")
+            .order_by("submitted_at")
+        )
+
 class TeacherGradeAttemptView(APIView):
     permission_classes = [permissions.IsAdminUser]
 
     def post(self, request, attempt_id):
         attempt = get_object_or_404(ExamAttempt, pk=attempt_id)
-        serializer = GradeSubmissionSerializer(data=request.data)
 
+        # ---- Backward-compat normalization (accept dict or list) ----
+        data = request.data.copy()
+        scores = data.get("scores")
+        if isinstance(scores, dict):
+            # convert {"12": 9, "13": 4} -> [{"criterion_id": 12, "achieved_points": 9}, ...]
+            data["scores"] = [
+                {"criterion_id": int(k), "achieved_points": v} for k, v in scores.items()
+            ]
+
+        serializer = TeacherGradingSerializer(
+            data=data,
+            context={"request": request, "attempt": attempt},
+        )
         if not serializer.is_valid():
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
         scores_data = serializer.validated_data["scores"]
         feedback = serializer.validated_data.get("feedback", "")
 
-        for criterion_id, points in scores_data.items():
-            criterion = get_object_or_404(
-                ExamCriterion, pk=criterion_id, exam=attempt.exam
-            )
+        for item in scores_data:
+            criterion_id = item["criterion_id"]
+            points = item["achieved_points"]
+            criterion = get_object_or_404(ExamCriterion, pk=criterion_id, exam=attempt.exam)
             CriterionScore.objects.update_or_create(
                 attempt=attempt,
                 criterion=criterion,
@@ -46,19 +84,12 @@ class TeacherGradeAttemptView(APIView):
         attempt.feedback = feedback
         attempt.graded_by = request.user
         attempt.status = ExamAttempt.Status.GRADED
-        attempt.save()
+        attempt.graded_at = timezone.now()
+        attempt.save(update_fields=["feedback", "graded_by", "status", "graded_at"])
 
-        return Response(
-            {"message": "Bewertung erfolgreich gespeichert."}, status=status.HTTP_200_OK
-        )
-
+        return Response({"message": "Bewertung erfolgreich gespeichert."}, status=status.HTTP_200_OK)
 
 class AllExamsListView(generics.ListAPIView):
-    from ..models import Exam
-    from ..serializers import ExamListSerializer
-
     queryset = Exam.objects.all()
     serializer_class = ExamListSerializer
-    permission_classes = [
-        permissions.IsAuthenticated
-    ]  # Alle authentifizierten User können Exams sehen
+    permission_classes = [permissions.IsAuthenticated]

--- a/elearning/tests/final_exam/test_teacher_views.py
+++ b/elearning/tests/final_exam/test_teacher_views.py
@@ -1,0 +1,217 @@
+"""
+Final Exam – Teacher Views Test Suite
+
+Covers:
+- TeacherSubmissionsListView (admin-only, lists SUBMITTED attempts ordered by submitted_at)
+- TeacherGradeAttemptView (admin-only grading: creates/updates CriterionScore, sets feedback/graded_by/status)
+- AllExamsListView (authenticated list)
+
+Author: DSP Development Team
+Date: 2025-09-10
+"""
+
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework.test import APIClient
+from django.utils import timezone
+
+from elearning.final_exam.models import (
+    Exam, ExamAttempt, ExamCriterion, CriterionScore
+)
+
+User = get_user_model()
+
+class TeacherExamViewsTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        # Users
+        cls.student = User.objects.create_user(username="student", email="s@example.com", password="pass")
+        cls.teacher_admin = User.objects.create_user(username="admin", email="a@example.com", password="pass")
+        cls.teacher_admin.is_staff = True
+        cls.teacher_admin.save()
+
+        # Exam
+        cls.exam = Exam.objects.create(title="Python Basics", duration_weeks=8, description="Intro to Python")
+        cls.other_exam = Exam.objects.create(title="Data Science Intro", duration_weeks=6, description="Basics of Data Science")
+
+        # Criteria
+        cls.crit_1 = ExamCriterion.objects.create(
+            exam=cls.exam, title="Correctness", description="Korrektheit bewerten", max_points=10
+        )
+        cls.crit_2 = ExamCriterion.objects.create(
+            exam=cls.exam, title="Style", description="Code-Stil bewerten", max_points=5
+        )
+
+        # Criterion for a different exam (used to test 404 on cross-exam scoring)
+        cls.other_exam_crit = ExamCriterion.objects.create(exam=cls.other_exam, title="Irrelevant", description="Falsches Exam", max_points=3)
+
+        # Attempts (SUBMITTED) – order by submitted_at
+        cls.attempt_early = ExamAttempt.objects.create(
+            user=cls.student, exam=cls.exam,
+            status=ExamAttempt.Status.SUBMITTED,
+            submitted_at=timezone.now() - timezone.timedelta(hours=2),
+        )
+        cls.attempt_late = ExamAttempt.objects.create(
+            user=cls.student, exam=cls.exam,
+            status=ExamAttempt.Status.SUBMITTED,
+            submitted_at=timezone.now() - timezone.timedelta(hours=1),
+        )
+
+        # A graded attempt (should NOT appear in submissions list)
+        ExamAttempt.objects.bulk_create([
+            ExamAttempt(
+                user=cls.student,
+                exam=cls.exam,
+                status=ExamAttempt.Status.GRADED,
+                submitted_at=timezone.now() - timezone.timedelta(hours=3),
+            )
+        ])
+        # get a handle to the created object (optional, but handy)
+        cls.attempt_graded = ExamAttempt.objects.filter(
+            user=cls.student, exam=cls.exam, status=ExamAttempt.Status.GRADED
+        ).order_by("id").first()
+
+    def setUp(self):
+        self.client = APIClient()
+
+    # -------- URL helpers (match show_urls names) --------
+
+    def _submissions_url(self):
+        return reverse("elearning:exams:teacher-submissions")
+
+    def _grade_url(self, attempt_id):
+        return reverse("elearning:exams:teacher-grade-attempt", kwargs={"attempt_id": attempt_id})
+
+    def _exams_list_url(self):
+        return reverse("elearning:exams:all-exams-list")
+
+    # ------------- TeacherSubmissionListView ----------------
+
+    def test_teacher_submissions_requires_admin(self):
+        # Unauthenticated
+        resp = self.client.get(self._submissions_url())
+        self.assertEqual(resp.status_code, 401)
+
+        # Authenticated non-admin
+        self.client.force_authenticate(user=self.student)
+        resp = self.client.get(self._submissions_url())
+        self.assertIn(resp.status_code, (401, 403))  # DRF version dependent
+
+        # Authenticated admin
+        self.client.force_authenticate(user=self.teacher_admin)
+        resp = self.client.get(self._submissions_url())
+        self.assertEqual(resp.status_code, 200)
+
+    def test_teacher_submissions_lists_only_submitted_sorted_by_submitted_at(self):
+        self.client.force_authenticate(self.teacher_admin)
+        resp = self.client.get(self._submissions_url())
+        self.assertEqual(resp.status_code, 200)
+
+        data = resp.json()
+        # Should include only the two SUBMITTED attempts, ordered by submitted_at (early -> late)
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]["id"], self.attempt_early.id)
+        self.assertEqual(data[1]["id"], self.attempt_late.id)
+
+    # ------------- TeacherGradeAttemptView ----------------
+
+    def test_grade_requires_admin(self):
+        url = self._grade_url(self.attempt_early.id)
+
+        # unauthenticated
+        resp = self.client.post(url, data={"scores": {}}, format="json")
+        self.assertEqual(resp.status_code, 401)
+
+        # non-admin
+        self.client.force_authenticate(self.student)
+        resp = self.client.post(url, data={"scores": {}}, format="json")
+        self.assertEqual(resp.status_code, 403)
+
+    def test_grade_valid_payload_creates_scores_and_updates_Attempt(self):
+        self.client.force_authenticate(self.teacher_admin)
+        url = self._grade_url(self.attempt_early.id)
+
+        payload = {
+            "scores": {
+                str(self.crit_1.id): 9.0,
+                str(self.crit_2.id): 4.0,
+            },
+            "feedback": "Good job overall."
+        }
+
+        resp = self.client.post(url, data=payload, format="json")
+        self.assertEqual(resp.status_code, 200)
+
+        # Attempt should be updated
+        self.attempt_early.refresh_from_db()
+        self.assertEqual(self.attempt_early.status, ExamAttempt.Status.GRADED)
+        self.assertEqual(self.attempt_early.feedback, "Good job overall.")
+        self.assertEqual(self.attempt_early.graded_by, self.teacher_admin)
+
+        # CriterionScores should be created
+        cs1 = CriterionScore.objects.get(attempt=self.attempt_early, criterion=self.crit_1)
+        cs2 = CriterionScore.objects.get(attempt=self.attempt_early, criterion=self.crit_2)
+        self.assertEqual(cs1.achieved_points, 9.0)
+        self.assertEqual(cs2.achieved_points, 4.0)
+
+    def test_grade_updates_existing_scores_idempotently(self):
+        # First grade
+        self.client.force_authenticate(self.teacher_admin)
+        url = self._grade_url(self.attempt_late.id)
+
+        payload1 = {"scores": {str(self.crit_1.id): "8.0", str(self.crit_2.id): "5.0"}, "feedback": "v1"}
+        resp = self.client.post(url, data=payload1, format="json")
+        self.assertEqual(resp.status_code, 200)
+
+        # Second grade (update values)
+        payload2 = {"scores": {str(self.crit_1.id): "10.0", str(self.crit_2.id): "3.0"}, "feedback": "v2"}
+        resp = self.client.post(url, data=payload2, format="json")
+        self.assertEqual(resp.status_code, 200)
+
+        cs1 = CriterionScore.objects.get(attempt=self.attempt_late, criterion=self.crit_1)
+        cs2 = CriterionScore.objects.get(attempt=self.attempt_late, criterion=self.crit_2)
+        self.assertEqual(cs1.achieved_points, 10.0)
+        self.assertEqual(cs2.achieved_points, 3.0)
+
+        self.attempt_late.refresh_from_db()
+        self.assertEqual(self.attempt_late.feedback, "v2")
+        self.assertEqual(self.attempt_late.status, ExamAttempt.Status.GRADED)
+        self.assertEqual(self.attempt_late.graded_by_id, self.teacher_admin.id)
+
+    def test_grade_invalid_payload_returns_400(self):
+        self.client.force_authenticate(self.teacher_admin)
+        url = self._grade_url(self.attempt_early.id)
+
+        # Missing 'scores'
+        resp = self.client.post(url, data={"feedback": "x"}, format="json")
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("scores", resp.json())
+
+    def test_grade_404_when_criterion_not_in_attempt_exam(self):
+        self.client.force_authenticate(self.teacher_admin)
+        url = self._grade_url(self.attempt_early.id)
+
+        # Include a criterion from a different exam -> should 404 inside the grading loop
+        payload = {
+            "scores": {
+                str(self.other_exam_crit.id): 1.0,  # wrong exam
+            }
+        }
+        resp = self.client.post(url, data=payload, format="json")
+        self.assertEqual(resp.status_code, 400)
+
+        # ---------- AllExamsListView ----------
+
+    def test_all_exams_requires_auth(self):
+        # anon
+        resp = self.client.get(self._exams_list_url())
+        self.assertEqual(resp.status_code, 401)
+
+        # authenticated non-admin ok
+        self.client.force_authenticate(self.student)
+        resp = self.client.get(self._exams_list_url())
+        self.assertEqual(resp.status_code, 200)
+        self.assertGreaterEqual(len(resp.json()), 2)  # exam + other_exam exist
+
+

--- a/elearning/tests/final_exam/test_teacher_views.py
+++ b/elearning/tests/final_exam/test_teacher_views.py
@@ -16,61 +16,86 @@ from django.urls import reverse
 from rest_framework.test import APIClient
 from django.utils import timezone
 
-from elearning.final_exam.models import (
-    Exam, ExamAttempt, ExamCriterion, CriterionScore
-)
+from elearning.final_exam.models import Exam, ExamAttempt, ExamCriterion, CriterionScore
 
 User = get_user_model()
+
 
 class TeacherExamViewsTests(TestCase):
     @classmethod
     def setUpTestData(cls):
         # Users
-        cls.student = User.objects.create_user(username="student", email="s@example.com", password="pass")
-        cls.teacher_admin = User.objects.create_user(username="admin", email="a@example.com", password="pass")
+        cls.student = User.objects.create_user(
+            username="student", email="s@example.com", password="pass"
+        )
+        cls.teacher_admin = User.objects.create_user(
+            username="admin", email="a@example.com", password="pass"
+        )
         cls.teacher_admin.is_staff = True
         cls.teacher_admin.save()
 
         # Exam
-        cls.exam = Exam.objects.create(title="Python Basics", duration_weeks=8, description="Intro to Python")
-        cls.other_exam = Exam.objects.create(title="Data Science Intro", duration_weeks=6, description="Basics of Data Science")
+        cls.exam = Exam.objects.create(
+            title="Python Basics", duration_weeks=8, description="Intro to Python"
+        )
+        cls.other_exam = Exam.objects.create(
+            title="Data Science Intro",
+            duration_weeks=6,
+            description="Basics of Data Science",
+        )
 
         # Criteria
         cls.crit_1 = ExamCriterion.objects.create(
-            exam=cls.exam, title="Correctness", description="Korrektheit bewerten", max_points=10
+            exam=cls.exam,
+            title="Correctness",
+            description="Korrektheit bewerten",
+            max_points=10,
         )
         cls.crit_2 = ExamCriterion.objects.create(
             exam=cls.exam, title="Style", description="Code-Stil bewerten", max_points=5
         )
 
         # Criterion for a different exam (used to test 404 on cross-exam scoring)
-        cls.other_exam_crit = ExamCriterion.objects.create(exam=cls.other_exam, title="Irrelevant", description="Falsches Exam", max_points=3)
+        cls.other_exam_crit = ExamCriterion.objects.create(
+            exam=cls.other_exam,
+            title="Irrelevant",
+            description="Falsches Exam",
+            max_points=3,
+        )
 
         # Attempts (SUBMITTED) – order by submitted_at
         cls.attempt_early = ExamAttempt.objects.create(
-            user=cls.student, exam=cls.exam,
+            user=cls.student,
+            exam=cls.exam,
             status=ExamAttempt.Status.SUBMITTED,
             submitted_at=timezone.now() - timezone.timedelta(hours=2),
         )
         cls.attempt_late = ExamAttempt.objects.create(
-            user=cls.student, exam=cls.exam,
+            user=cls.student,
+            exam=cls.exam,
             status=ExamAttempt.Status.SUBMITTED,
             submitted_at=timezone.now() - timezone.timedelta(hours=1),
         )
 
         # A graded attempt (should NOT appear in submissions list)
-        ExamAttempt.objects.bulk_create([
-            ExamAttempt(
-                user=cls.student,
-                exam=cls.exam,
-                status=ExamAttempt.Status.GRADED,
-                submitted_at=timezone.now() - timezone.timedelta(hours=3),
-            )
-        ])
+        ExamAttempt.objects.bulk_create(
+            [
+                ExamAttempt(
+                    user=cls.student,
+                    exam=cls.exam,
+                    status=ExamAttempt.Status.GRADED,
+                    submitted_at=timezone.now() - timezone.timedelta(hours=3),
+                )
+            ]
+        )
         # get a handle to the created object (optional, but handy)
-        cls.attempt_graded = ExamAttempt.objects.filter(
-            user=cls.student, exam=cls.exam, status=ExamAttempt.Status.GRADED
-        ).order_by("id").first()
+        cls.attempt_graded = (
+            ExamAttempt.objects.filter(
+                user=cls.student, exam=cls.exam, status=ExamAttempt.Status.GRADED
+            )
+            .order_by("id")
+            .first()
+        )
 
     def setUp(self):
         self.client = APIClient()
@@ -81,7 +106,9 @@ class TeacherExamViewsTests(TestCase):
         return reverse("elearning:exams:teacher-submissions")
 
     def _grade_url(self, attempt_id):
-        return reverse("elearning:exams:teacher-grade-attempt", kwargs={"attempt_id": attempt_id})
+        return reverse(
+            "elearning:exams:teacher-grade-attempt", kwargs={"attempt_id": attempt_id}
+        )
 
     def _exams_list_url(self):
         return reverse("elearning:exams:all-exams-list")
@@ -137,7 +164,7 @@ class TeacherExamViewsTests(TestCase):
                 str(self.crit_1.id): 9.0,
                 str(self.crit_2.id): 4.0,
             },
-            "feedback": "Good job overall."
+            "feedback": "Good job overall.",
         }
 
         resp = self.client.post(url, data=payload, format="json")
@@ -150,8 +177,12 @@ class TeacherExamViewsTests(TestCase):
         self.assertEqual(self.attempt_early.graded_by, self.teacher_admin)
 
         # CriterionScores should be created
-        cs1 = CriterionScore.objects.get(attempt=self.attempt_early, criterion=self.crit_1)
-        cs2 = CriterionScore.objects.get(attempt=self.attempt_early, criterion=self.crit_2)
+        cs1 = CriterionScore.objects.get(
+            attempt=self.attempt_early, criterion=self.crit_1
+        )
+        cs2 = CriterionScore.objects.get(
+            attempt=self.attempt_early, criterion=self.crit_2
+        )
         self.assertEqual(cs1.achieved_points, 9.0)
         self.assertEqual(cs2.achieved_points, 4.0)
 
@@ -160,17 +191,27 @@ class TeacherExamViewsTests(TestCase):
         self.client.force_authenticate(self.teacher_admin)
         url = self._grade_url(self.attempt_late.id)
 
-        payload1 = {"scores": {str(self.crit_1.id): "8.0", str(self.crit_2.id): "5.0"}, "feedback": "v1"}
+        payload1 = {
+            "scores": {str(self.crit_1.id): "8.0", str(self.crit_2.id): "5.0"},
+            "feedback": "v1",
+        }
         resp = self.client.post(url, data=payload1, format="json")
         self.assertEqual(resp.status_code, 200)
 
         # Second grade (update values)
-        payload2 = {"scores": {str(self.crit_1.id): "10.0", str(self.crit_2.id): "3.0"}, "feedback": "v2"}
+        payload2 = {
+            "scores": {str(self.crit_1.id): "10.0", str(self.crit_2.id): "3.0"},
+            "feedback": "v2",
+        }
         resp = self.client.post(url, data=payload2, format="json")
         self.assertEqual(resp.status_code, 200)
 
-        cs1 = CriterionScore.objects.get(attempt=self.attempt_late, criterion=self.crit_1)
-        cs2 = CriterionScore.objects.get(attempt=self.attempt_late, criterion=self.crit_2)
+        cs1 = CriterionScore.objects.get(
+            attempt=self.attempt_late, criterion=self.crit_1
+        )
+        cs2 = CriterionScore.objects.get(
+            attempt=self.attempt_late, criterion=self.crit_2
+        )
         self.assertEqual(cs1.achieved_points, 10.0)
         self.assertEqual(cs2.achieved_points, 3.0)
 
@@ -213,5 +254,3 @@ class TeacherExamViewsTests(TestCase):
         resp = self.client.get(self._exams_list_url())
         self.assertEqual(resp.status_code, 200)
         self.assertGreaterEqual(len(resp.json()), 2)  # exam + other_exam exist
-
-


### PR DESCRIPTION
This PR adds the teacher-facing final-exam views and tests: an admin-only submissions list (_GET /api/elearning/exams/teacher/submissions/_) that returns only SUBMITTED attempts ordered by **submitted_at**, an admin-only grading endpoint (_POST /api/elearning/exams/teacher/submissions/<attempt_id>/grade/_) that upserts per-criterion CriterionScores, sets feedback, graded_by, and status=GRADED, returning 404 when a score targets a criterion outside the attempt’s exam and 400 for validation errors, plus an authenticated all-exams list (GET /api/elearning/exams/all/). Serializers were aligned with the current model shape (**ExamCriterionSerializer** with **max_points, CriterionScoreSerializer** using **achieved_points**, **TeacherGradingSerializer** for input validation, and **TeacherSubmissionSerializer** including **user** and **graded_by**), and **ExamSerializer** now exposes **total_max_points**.