### PR TITLE
Hotfix/cookiefreelogin

### DIFF
--- a/elearning/urls.py
+++ b/elearning/urls.py
@@ -33,7 +33,7 @@ from .modules.views import article_processing_views as article_views
 from .modules.views import content_processing_views as content_views
 from .modules.views import video_url_views as video_views
 from .final_exam import views as exam_views
-from .users.views.auth_views import CustomTokenRefreshView
+from .users.views.auth_views import CustomTokenRefreshView, SessionObtainView
 
 app_name = "elearning"
 
@@ -292,6 +292,7 @@ urlpatterns: List[URLPattern] = [
         user_views.CustomTokenObtainPairView.as_view(),
         name="token_obtain_pair",
     ),
+    path("session/", SessionObtainView.as_view(), name="session"),
     path("token/refresh/", CustomTokenRefreshView.as_view(), name="token_refresh"),
     path("token/verify/", TokenVerifyView.as_view(), name="token_verify"),
     # Functional area URL includes with proper namespacing

--- a/elearning/users/views/auth_views.py
+++ b/elearning/users/views/auth_views.py
@@ -81,6 +81,7 @@ class CustomTokenObtainPairView(TokenObtainPairView):
                 )
         return response
 
+
 class SessionObtainView(TokenObtainPairView):
     """
     View mirroring CustomTokenObtainView with no max_age value, creating a session cookie.

--- a/elearning/users/views/auth_views.py
+++ b/elearning/users/views/auth_views.py
@@ -81,6 +81,39 @@ class CustomTokenObtainPairView(TokenObtainPairView):
                 )
         return response
 
+class SessionObtainView(TokenObtainPairView):
+    """
+    View mirroring CustomTokenObtainView with no max_age value, creating a session cookie.
+    This works even when cookies are disabled.
+    """
+
+    def post(self, request, *args, **kwargs):
+        response = super().post(request, *args, **kwargs)
+        if response.status_code == 200:
+            data = response.data
+            refresh = data.pop("refresh", None)
+            access = data.pop("access", None)
+
+            if refresh:
+                response.set_cookie(
+                    "refresh_token",
+                    refresh,
+                    httponly=True,
+                    secure=True,
+                    samesite="None",
+                    path="/",
+                )
+            if access:
+                response.set_cookie(
+                    "access_token",
+                    access,
+                    httponly=True,
+                    secure=True,
+                    samesite="None",  # TODO: Definitely change this to Strict on Prod!
+                    path="/",
+                )
+        return response
+
 
 class CustomTokenRefreshView(TokenRefreshView):
     """


### PR DESCRIPTION
Local Storage im login.tsx zu try/catchen hilft, ist aber nicht alles.
Hab versucht Session Cookies zu benutzen, um den Fehler zu umgehen. Leider wirft es trotzdem. Liegt daran, dass der Browser Third Party Cookies blockiert und wir mit unseren verschiedenen Ports eine third party sind. Eventuell ist das auf der Domain besser? Kann ich leider nicht sagen.

Gehört zusammen mit dem Commit aus dem Frontend https://github.com/LDM010795/DSP-E-Learning/pull/72
